### PR TITLE
Bump go version to 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pion/ci-sandbox
 
-go 1.20
+go 1.21
 
 require (
 	github.com/pion/transport/v3 v3.0.7


### PR DESCRIPTION
#### Description
Bumps the go version to 1.21

#### Reference issue
N/A, fixes the CI
